### PR TITLE
Override dompurify to 3.4.0 to patch GHSA-39q2-94rc-95cp

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
     },
   },
   "overrides": {
+    "dompurify": "3.4.0",
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
   },
@@ -422,7 +423,7 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
+    "dompurify": ["dompurify@3.4.0", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.325", "", {}, "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "overrides": {
     "rollup": ">=4.59.0",
-    "minimatch": ">=10.2.3"
+    "minimatch": ">=10.2.3",
+    "dompurify": "3.4.0"
   }
 }


### PR DESCRIPTION
Fixes bun audit failure from transitive dompurify pulled in as an optional dep of jspdf. Pinned via overrides to keep jspdf resolution at a patched version.